### PR TITLE
Correct description in tag kinds page

### DIFF
--- a/pages/spec/tag_kinds.md
+++ b/pages/spec/tag_kinds.md
@@ -54,7 +54,7 @@ block tag.
 
 In normalized form, the modifier tags appear on a single line at the bottom of the doc comment.
 
-**Examples of block tags:**
+**Examples of modifier tags:**
 ```ts
 /**
  * This is the special summary section.


### PR DESCRIPTION
Hi, I've just found some sub-heading in tag kinds page showing something different stuff, probably copy-n-pasted, I guess.

This is just a tiny change but I thought it's good to modify for a clarification reason.

Thanks for your review on my change.
